### PR TITLE
Add started_at

### DIFF
--- a/sources/api/actions/checks/createrun.rb
+++ b/sources/api/actions/checks/createrun.rb
@@ -13,7 +13,7 @@ module Action
         end
       end
       
-      attr_accessor :name, :head_branch, :head_sha, :status, :conclusion, :completed_at, :output
+      attr_accessor :name, :head_branch, :head_sha, :status, :started_at, :conclusion, :completed_at, :output
       
       def initialize
         super do |a|
@@ -31,7 +31,8 @@ module Action
           :head_sha => @head_sha,
           :status => @status
         }
-        
+
+        @payload[:started_at] = defined? @started_at ? @started_at.to_s : Time.now.utc.iso8601
         @payload[:conclusion] = @conclusion if defined? @conclusion
         @payload[:output] = @output.payload if defined? @output
         @payload[:completed_at] = @completed_at.to_s if defined? @completed_at

--- a/sources/api/actions/checks/updaterun.rb
+++ b/sources/api/actions/checks/updaterun.rb
@@ -8,7 +8,7 @@ module Action
   module Checks
     class UpdateRun < API::Github::Checks::ChecksAction
       
-      attr_accessor :id, :name, :head_branch, :head_sha, :status, :conclusion, :output
+      attr_accessor :id, :name, :head_branch, :head_sha, :status, :started_at, :conclusion, :output
       attr_reader :payload
       
       def initialize
@@ -26,6 +26,7 @@ module Action
         @payload[:conclusion] = @conclusion if defined? @conclusion
         @payload[:output] = @output.payload if defined? @output
         
+        @payload[:started_at] = defined? @started_at ? @started_at.to_s : Time.now.utc.iso8601
         @payload[:completed_at] = Time.now.utc.iso8601
       end
       

--- a/sources/core/checksmanager.rb
+++ b/sources/core/checksmanager.rb
@@ -21,7 +21,7 @@ module Core
         cr.owner = check_ref.owner
         cr.repository = check_ref.repository
         cr.id = check_ref.id
-        
+        cr.started_at = check_ref.started_at
         cr.conclusion = conclusion.to_s
         if block_given?
           output = API::Github::Checks::Output.new


### PR DESCRIPTION
The goal is to prevent GitHub from reporting:
`... Successful in -1m`

I can't find tests for this, and I'm not really claiming to speak Ruby, please consider this more an outline of an idea to try to do the right thing.